### PR TITLE
Protect "Encaged <name> Soul" items from being opened by the Looter

### DIFF
--- a/src/services/looter.lua
+++ b/src/services/looter.lua
@@ -50,6 +50,16 @@ end
 -- Looter
 -- ============================================================================
 
+local doNotLootIDs = {
+	-- These "Encaged" Souls become "Docile" Souls after 15 minutes in the bags (different item ID).
+	-- The "Docile" variant contains the real loot (Soul reagent or a pet).
+	-- If opened prematurely (still "Encaged"), it just gives some minor reagents.
+	[200931] = true, -- Encaged Fiery Soul
+	[200932] = true, -- Encaged Airy Soul
+	[200934] = true, -- Encaged Frosty Soul
+	[200936] = true, -- Encaged Earthen Soul
+}
+	
 function Looter:Start()
   if self.ticker and not self.ticker:IsCancelled() then return end
 
@@ -61,7 +71,7 @@ function Looter:Start()
 
   -- Remove non-lootable items.
   for i = #self.items, 1, -1 do
-    if not self.items[i].lootable then
+    if not self.items[i].lootable or doNotLootIDs[self.items[i].id] then
       table.remove(self.items, i)
     end
   end


### PR DESCRIPTION
These "Encaged" Souls become "Docile" Souls after 15 minutes in the bag. You do not want to loot them before, as this would give you just some crap reagents, instead of the pet or the valuable "Soul" reagent.

[Source](https://www.wowhead.com/item=200931/encaged-fiery-soul#comments:id=5492197)

Reasoning:

I have Dejunk's  looter on a very convenient Shift-Z hotkey and my muscle memory is so that I have already destroyed at least a dozen of these "Soul"s just by hitting the hotkey out of habit. This change stops this madness ;)

Note that there is no risk accumulating unopened Souls, as these _will_ convert into "Docile" Souls, which have a different ID and therefore will be opened by the Looter (and are fine to be opened).

The "Soul" reagent is needed for crafting various toys that sell fine on the AH, so, yes, this is still important, not legacy. The RNG pet from this is even more valuable.